### PR TITLE
bump symfony version to 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.3.3",
         "xi/sms": "<=dev-master@dev",
-        "symfony/framework-bundle": ">=2.1.0,<2.3-dev"
+        "symfony/framework-bundle": ">=2.1.0,<2.5"
     },
 
     "require-dev": {


### PR DESCRIPTION
There is stable 2.5 version Symfony. Can we upgrade this?
